### PR TITLE
fix typo in sample program

### DIFF
--- a/ryu/app/simple_switch.py
+++ b/ryu/app/simple_switch.py
@@ -84,7 +84,7 @@ class SimpleSwitch(app_manager.RyuApp):
     def _port_status_handler(self, ev):
         msg = ev.msg
         reason = msg.reason
-        port_no = msg.port_no
+        port_no = msg.desc.port_no
 
         ofproto = msg.datapath.ofproto
         if reason == ofproto.OFPPR_ADD:


### PR DESCRIPTION
port_no is not a member of msg, but a member of msg.desc.
