### PR TITLE
Nx match extension

### DIFF
--- a/ryu/ofproto/nx_match.py
+++ b/ryu/ofproto/nx_match.py
@@ -124,11 +124,11 @@ class ClsRule(object):
 
     def set_dl_vlan(self, dl_vlan):
         self.wc.wildcards &= ~ofproto_v1_0.OFPFW_DL_VLAN
-	self.flow.dl_vlan = dl_vlan
+        self.flow.dl_vlan = dl_vlan
 
     def set_dl_vlan_pcp(self, dl_vlan_pcp):
-	self.wc.wildcards &= ~ofproto_v1_0.OFPFW_DL_VLAN_PCP
-	self.flow.dl_vlan_pcp = dl_vlan_pcp
+        self.wc.wildcards &= ~ofproto_v1_0.OFPFW_DL_VLAN_PCP
+        self.flow.dl_vlan_pcp = dl_vlan_pcp
 
     def set_dl_dst(self, dl_dst):
         self.flow.dl_dst = dl_dst
@@ -175,18 +175,18 @@ class ClsRule(object):
         self.flow.nw_proto = nw_proto
 
     def set_nw_src(self, nw_src):
-        self.set_nw_src_masked(nw_src, 0) #mask is null for a exact match
+        self.set_nw_src_masked(nw_src, 0)  # mask is null for a exact match
 
     def set_nw_src_masked(self, nw_src, mask):
         self.flow.nw_src = nw_src
-        self.wc.nw_src_mask = mask #mask is opposite of CIDR
+        self.wc.nw_src_mask = mask  # mask is opposite of CIDR
 
     def set_nw_dst(self, nw_dst):
-        self.set_nw_dst_masked(nw_dst, 0) #mask is null for a exact match
+        self.set_nw_dst_masked(nw_dst, 0)  # mask is null for a exact match
 
     def set_nw_dst_masked(self, nw_dst, mask):
         self.flow.nw_dst = nw_dst
-        self.wc.nw_dst_mask = mask #mask is opposite of CIDR
+        self.wc.nw_dst_mask = mask  # mask is opposite of CIDR
 
     def set_nw_dscp(self, nw_dscp):
         self.wc.wildcards &= ~FWW_NW_DSCP
@@ -329,7 +329,7 @@ class ClsRule(object):
 
         if self.flow.dl_vlan_pcp != 0:
             wildcards &= ~ofproto_v1_0.OFPFW_DL_VLAN_PCP
-	
+
         if self.flow.nw_tos != 0:
             wildcards &= ~ofproto_v1_0.OFPFW_NW_TOS
 
@@ -338,11 +338,13 @@ class ClsRule(object):
 
         if self.flow.nw_src != 0:
             wildcards &= ~ofproto_v1_0.OFPFW_NW_SRC_MASK
-            wildcards |= (self.wc.nw_src_mask % 32) << 8 #maximum size of 32 to prevent changes on other bits
+            # maximum size of 32 to prevent changes on other bits
+            wildcards |= (self.wc.nw_src_mask % 32) << 8
 
         if self.flow.nw_dst != 0:
             wildcards &= ~ofproto_v1_0.OFPFW_NW_DST_MASK
-            wildcards |= (self.wc.nw_dst_mask % 32) << 14 #maximum size of 32 to prevent changes on other bits
+            # maximum size of 32 to prevent changes on other bits
+            wildcards |= (self.wc.nw_dst_mask % 32) << 14
 
         if self.flow.tp_src != 0:
             wildcards &= ~ofproto_v1_0.OFPFW_TP_SRC
@@ -350,12 +352,13 @@ class ClsRule(object):
         if self.flow.tp_dst != 0:
             wildcards &= ~ofproto_v1_0.OFPFW_TP_DST
 
-	#FIXME: add support for arp, icmp, etc
-	
+        #FIXME: add support for arp, icmp, etc
+
         return (wildcards, self.flow.in_port, self.flow.dl_src,
-                self.flow.dl_dst, self.flow.dl_vlan, self.flow.dl_vlan_pcp, self.flow.dl_type,
-                self.flow.nw_tos & IP_DSCP_MASK, self.flow.nw_proto,
-                self.flow.nw_src, self.flow.nw_dst, self.flow.tp_src, self.flow.tp_dst)
+                self.flow.dl_dst, self.flow.dl_vlan, self.flow.dl_vlan_pcp,
+                self.flow.dl_type, self.flow.nw_tos & IP_DSCP_MASK,
+                self.flow.nw_proto, self.flow.nw_src, self.flow.nw_dst,
+                self.flow.tp_src, self.flow.tp_dst)
 
 
 def _set_nxm_headers(nxm_headers):


### PR DESCRIPTION
Extended the class ClsRule file nx_match to support dl_vlan, fl_vlan_pcp, nw_tos, nw_proto, nw_src, nw_dst, tp_src and dp_dst (See the FIXME tag). Tested with Pica Pronto 3295 switches.
