### PR TITLE
Add  special group identifier values defined on OpenFlow 1.3.1

### DIFF
--- a/ryu/ofproto/ofproto_v1_3.py
+++ b/ryu/ofproto/ofproto_v1_3.py
@@ -416,6 +416,14 @@ OFPGC_ADD = 0  # New group.
 OFPGC_MODIFY = 1  # Modify all matching groups.
 OFPGC_DELETE = 2  # Delete all matching groups.
 
+# enum ofp_group
+OFPG_MAX = 0xffffff00 # Last usable group number.
+#Fake groups
+OFPG_ALL = 0xfffffffc # Represents all groups for group delete commands.
+OFPG_ANY = 0xffffffff #Wildcard group used only for flow stats requests.
+                      #Selects all flows regardless of group
+                      #(including flows with no group).
+
 # enum ofp_group_type
 OFPGT_ALL = 0  # All (multicast/broadcast) group.
 OFPGT_SELECT = 1  # Select group.


### PR DESCRIPTION
This commit add group special values which were missing on OpenFlow 1.3 and were added in the 1.3.1 version. 

It is useful to create a flow_mod message with an out_group with no group restrictions and for flow_stats messages.
