### PR TITLE
MAC, IPv4, IPv6 changes in the Ryu's Packet library

### DIFF
--- a/ryu/lib/addrconv.py
+++ b/ryu/lib/addrconv.py
@@ -38,3 +38,30 @@ class mac_mydialect(netaddr.mac_unix):
     word_fmt = '%.2x'
 mac = AddressConverter(netaddr.EUI, netaddr.strategy.eui48, version=48,
                        dialect=mac_mydialect)
+
+# Added by Omid ~
+def dynamic_type(cls, name, _type, length):
+    attrib = "_" + name
+
+    def getter(self):
+        return getattr(self, attrib)
+
+    def setter(self, value):
+        if len(value) == length:
+            setattr(self, attrib, value)
+        else:
+            try:
+                setattr(self, attrib, _type.text_to_bin(value))
+            except:
+                setattr(self, attrib, value)
+
+    setattr(cls, name, property(getter, setter))
+
+def ipv4_type(cls, name):
+    return dynamic_type(cls, name, ipv4, 4)
+
+def ipv6_type(cls, name):
+    return dynamic_type(cls, name, ipv6, 16)
+
+def mac_type(cls, name):
+    return dynamic_type(cls, name, mac, 6)

--- a/ryu/lib/packet/arp.py
+++ b/ryu/lib/packet/arp.py
@@ -27,7 +27,6 @@ ARP_REPLY = 2
 ARP_REV_REQUEST = 3
 ARP_REV_REPLY = 4
 
-
 class arp(packet_base.PacketBase):
     """ARP (RFC 826) header encoder/decoder class.
 
@@ -77,19 +76,26 @@ class arp(packet_base.PacketBase):
         (hwtype, proto, hlen, plen, opcode, src_mac, src_ip,
          dst_mac, dst_ip) = struct.unpack_from(cls._PACK_STR, buf)
         return cls(hwtype, proto, hlen, plen, opcode,
-                   addrconv.mac.bin_to_text(src_mac),
-                   addrconv.ipv4.bin_to_text(src_ip),
-                   addrconv.mac.bin_to_text(dst_mac),
-                   addrconv.ipv4.bin_to_text(dst_ip)), None, buf[arp._MIN_LEN:]
+                   src_mac,
+                   src_ip,
+                   dst_mac,
+                   dst_ip), None, buf[arp._MIN_LEN:]
 
     def serialize(self, payload, prev):
         return struct.pack(arp._PACK_STR, self.hwtype, self.proto,
                            self.hlen, self.plen, self.opcode,
-                           addrconv.mac.text_to_bin(self.src_mac),
-                           addrconv.ipv4.text_to_bin(self.src_ip),
-                           addrconv.mac.text_to_bin(self.dst_mac),
-                           addrconv.ipv4.text_to_bin(self.dst_ip))
+                           self.src_mac,
+                           self.src_ip,
+                           self.dst_mac,
+                           self.dst_ip)
 
+# Mac address
+addrconv.mac_type(arp,"src_mac")
+addrconv.mac_type(arp,"dst_mac")
+
+# IP address
+addrconv.ipv4_type(arp,"src_ip")
+addrconv.ipv4_type(arp,"dst_ip")
 
 def arp_ip(opcode, src_mac, src_ip, dst_mac, dst_ip):
     """A convenient wrapper for IPv4 ARP for Ethernet.

--- a/ryu/lib/packet/bpdu.py
+++ b/ryu/lib/packet/bpdu.py
@@ -348,13 +348,13 @@ class ConfigurationBPDUs(bpdu):
                          for i in range(0, 6)]
         mac_addr_list.reverse()
         mac_address_bin = binascii.a2b_hex(''.join(mac_addr_list))
-        mac_address = addrconv.mac.bin_to_text(mac_address_bin)
+        mac_address = mac_address_bin
 
         return priority, system_id_extension, mac_address
 
     @staticmethod
     def encode_bridge_id(priority, system_id_extension, mac_address):
-        mac_addr = int(binascii.hexlify(addrconv.mac.text_to_bin(mac_address)),
+        mac_addr = int(binascii.hexlify(mac_address),
                        16)
         return ((priority + system_id_extension) << 48) + mac_addr
 
@@ -375,6 +375,9 @@ class ConfigurationBPDUs(bpdu):
     @staticmethod
     def _encode_timer(timer):
         return timer * 0x100
+
+addrconv.mac_type(ConfigurationBPDUs, 'root_mac_address')
+addrconv.mac_type(ConfigurationBPDUs, 'bridge_mac_address')
 
 
 @bpdu.register_bpdu_type

--- a/ryu/lib/packet/ethernet.py
+++ b/ryu/lib/packet/ethernet.py
@@ -49,15 +49,14 @@ class ethernet(packet_base.PacketBase):
     @classmethod
     def parser(cls, buf):
         dst, src, ethertype = struct.unpack_from(cls._PACK_STR, buf)
-        return (cls(addrconv.mac.bin_to_text(dst),
-                    addrconv.mac.bin_to_text(src), ethertype),
+        return (cls(dst, src, ethertype),
                 ethernet.get_packet_type(ethertype),
                 buf[ethernet._MIN_LEN:])
 
     def serialize(self, payload, prev):
         return struct.pack(ethernet._PACK_STR,
-                           addrconv.mac.text_to_bin(self.dst),
-                           addrconv.mac.text_to_bin(self.src),
+                           self.dst,
+                           self.src,
                            self.ethertype)
 
     @classmethod
@@ -72,6 +71,9 @@ class ethernet(packet_base.PacketBase):
             type_ = ether.ETH_TYPE_IEEE802_3
         return cls._TYPES.get(type_)
 
+# Mac address
+addrconv.mac_type(ethernet,"src")
+addrconv.mac_type(ethernet,"dst")
 
 # copy vlan _TYPES
 ethernet._TYPES = vlan.vlan._TYPES

--- a/ryu/lib/packet/igmp.py
+++ b/ryu/lib/packet/igmp.py
@@ -103,17 +103,19 @@ class igmp(packet_base.PacketBase):
         (msgtype, maxresp, csum, address
          ) = struct.unpack_from(cls._PACK_STR, buf)
         return (cls(msgtype, maxresp, csum,
-                    addrconv.ipv4.bin_to_text(address)),
+                    address),
                 None,
                 buf[cls._MIN_LEN:])
 
     def serialize(self, payload, prev):
         hdr = bytearray(struct.pack(self._PACK_STR, self.msgtype,
                         self.maxresp, self.csum,
-                        addrconv.ipv4.text_to_bin(self.address)))
+                        self.address))
 
         if self.csum == 0:
             self.csum = packet_utils.checksum(hdr)
             struct.pack_into('!H', hdr, 2, self.csum)
 
         return hdr
+
+addrconv.ipv4_type(igmp, 'address')

--- a/ryu/lib/packet/ipv4.py
+++ b/ryu/lib/packet/ipv4.py
@@ -108,8 +108,8 @@ class ipv4(packet_base.PacketBase):
             option = None
         msg = cls(version, header_length, tos, total_length, identification,
                   flags, offset, ttl, proto, csum,
-                  addrconv.ipv4.bin_to_text(src),
-                  addrconv.ipv4.bin_to_text(dst), option)
+                  src,
+                  dst, option)
 
         return msg, ipv4.get_packet_type(proto), buf[length:total_length]
 
@@ -123,8 +123,8 @@ class ipv4(packet_base.PacketBase):
         struct.pack_into(ipv4._PACK_STR, hdr, 0, version, self.tos,
                          self.total_length, self.identification, flags,
                          self.ttl, self.proto, 0,
-                         addrconv.ipv4.text_to_bin(self.src),
-                         addrconv.ipv4.text_to_bin(self.dst))
+                         self.src,
+                         self.dst)
 
         if self.option:
             assert (length - ipv4._MIN_LEN) >= len(self.option)
@@ -133,6 +133,9 @@ class ipv4(packet_base.PacketBase):
         self.csum = packet_utils.checksum(hdr)
         struct.pack_into('!H', hdr, 10, self.csum)
         return hdr
+
+addrconv.ipv4_type( ipv4, 'src')
+addrconv.ipv4_type( ipv4, 'dst')
 
 ipv4.register_packet_type(icmp.icmp, inet.IPPROTO_ICMP)
 ipv4.register_packet_type(igmp.igmp, inet.IPPROTO_IGMP)

--- a/ryu/lib/packet/ipv6.py
+++ b/ryu/lib/packet/ipv6.py
@@ -78,8 +78,8 @@ class ipv6(packet_base.PacketBase):
         flow_label = v_tc_flow & 0xfffff
         hop_limit = hlim
         msg = cls(version, traffic_class, flow_label, payload_length,
-                  nxt, hop_limit, addrconv.ipv6.bin_to_text(src),
-                  addrconv.ipv6.bin_to_text(dst))
+                  nxt, hop_limit, src,
+                  dst)
         return (msg, ipv6.get_packet_type(nxt),
                 buf[cls._MIN_LEN:cls._MIN_LEN+payload_length])
 
@@ -89,9 +89,12 @@ class ipv6(packet_base.PacketBase):
                      self.flow_label << 12)
         struct.pack_into(ipv6._PACK_STR, hdr, 0, v_tc_flow,
                          self.payload_length, self.nxt, self.hop_limit,
-                         addrconv.ipv6.text_to_bin(self.src),
-                         addrconv.ipv6.text_to_bin(self.dst))
+                         self.src,
+                         self.dst)
         return hdr
+
+addrconv.ipv6_type(ipv6, 'src')
+addrconv.ipv6_type(ipv6, 'dst')
 
 ipv6.register_packet_type(icmpv6.icmpv6, inet.IPPROTO_ICMPV6)
 ipv6.register_packet_type(tcp.tcp, inet.IPPROTO_TCP)

--- a/ryu/lib/packet/packet_utils.py
+++ b/ryu/lib/packet/packet_utils.py
@@ -84,13 +84,13 @@ def checksum_ip(ipvx, length, payload):
     """
     if ipvx.version == 4:
         header = struct.pack(_IPV4_PSEUDO_HEADER_PACK_STR,
-                             addrconv.ipv4.text_to_bin(ipvx.src),
-                             addrconv.ipv4.text_to_bin(ipvx.dst),
+                             ipvx.src,
+                             ipvx.dst,
                              ipvx.proto, length)
     elif ipvx.version == 6:
         header = struct.pack(_IPV6_PSEUDO_HEADER_PACK_STR,
-                             addrconv.ipv6.text_to_bin(ipvx.src),
-                             addrconv.ipv6.text_to_bin(ipvx.dst),
+                             ipvx.src,
+                             ipvx.dst,
                              length, ipvx.nxt)
     else:
         raise ValueError('Unknown IP version %d' % ipvx.version)

--- a/ryu/lib/packet/slow.py
+++ b/ryu/lib/packet/slow.py
@@ -561,14 +561,14 @@ class lacp(packet_base.PacketBase):
         assert 0 == terminator_length
         return cls(version,
                    actor_system_priority,
-                   addrconv.mac.bin_to_text(actor_system),
+                   actor_system,
                    actor_key, actor_port_priority,
                    actor_port, actor_state_activity,
                    actor_state_timeout, actor_state_aggregation,
                    actor_state_synchronization, actor_state_collecting,
                    actor_state_distributing, actor_state_defaulted,
                    actor_state_expired, partner_system_priority,
-                   addrconv.mac.bin_to_text(partner_system),
+                   partner_system,
                    partner_key, partner_port_priority,
                    partner_port, partner_state_activity,
                    partner_state_timeout, partner_state_aggregation,
@@ -583,14 +583,14 @@ class lacp(packet_base.PacketBase):
         actor = struct.pack(self._ACTPRT_INFO_PACK_STR,
                             self.actor_tag, self.actor_length,
                             self.actor_system_priority,
-                            addrconv.mac.text_to_bin(self.actor_system),
+                            self.actor_system,
                             self.actor_key,
                             self.actor_port_priority, self.actor_port,
                             self.actor_state)
         partner = struct.pack(self._ACTPRT_INFO_PACK_STR,
                               self.partner_tag, self.partner_length,
                               self.partner_system_priority,
-                              addrconv.mac.text_to_bin(self.partner_system),
+                              self.partner_system,
                               self.partner_key,
                               self.partner_port_priority,
                               self.partner_port, self.partner_state)
@@ -602,3 +602,7 @@ class lacp(packet_base.PacketBase):
                                  self.terminator_tag,
                                  self.terminator_length)
         return header + actor + partner + collector + terminator
+
+
+addrconv.mac_type( slow, 'actor_system')
+addrconv.mac_type( slow, 'partner_system')

--- a/ryu/tests/unit/packet/test_arp.py
+++ b/ryu/tests/unit/packet/test_arp.py
@@ -41,17 +41,17 @@ class Test_arp(unittest.TestCase):
     hlen = 6
     plen = 4
     opcode = 1
-    src_mac = '00:07:0d:af:f4:54'
-    src_ip = '24.166.172.1'
-    dst_mac = '00:00:00:00:00:00'
-    dst_ip = '24.166.173.159'
+    src_mac = addrconv.mac.text_to_bin('00:07:0d:af:f4:54')
+    src_ip = addrconv.ipv4.text_to_bin('24.166.172.1')
+    dst_mac = addrconv.mac.text_to_bin('00:00:00:00:00:00')
+    dst_ip = addrconv.ipv4.text_to_bin('24.166.173.159')
 
     fmt = arp._PACK_STR
     buf = pack(fmt, hwtype, proto, hlen, plen, opcode,
-               addrconv.mac.text_to_bin(src_mac),
-               addrconv.ipv4.text_to_bin(src_ip),
-               addrconv.mac.text_to_bin(dst_mac),
-               addrconv.ipv4.text_to_bin(dst_ip))
+               src_mac,
+               src_ip,
+               dst_mac,
+               dst_ip)
 
     a = arp(hwtype, proto, hlen, plen, opcode, src_mac, src_ip, dst_mac,
             dst_ip)
@@ -108,10 +108,10 @@ class Test_arp(unittest.TestCase):
         eq_(res[2], self.hlen)
         eq_(res[3], self.plen)
         eq_(res[4], self.opcode)
-        eq_(res[5], addrconv.mac.text_to_bin(self.src_mac))
-        eq_(res[6], addrconv.ipv4.text_to_bin(self.src_ip))
-        eq_(res[7], addrconv.mac.text_to_bin(self.dst_mac))
-        eq_(res[8], addrconv.ipv4.text_to_bin(self.dst_ip))
+        eq_(res[5], self.src_mac)
+        eq_(res[6], self.src_ip)
+        eq_(res[7], self.dst_mac)
+        eq_(res[8], self.dst_ip)
 
     def _build_arp(self, vlan_enabled):
         if vlan_enabled is True:

--- a/ryu/tests/unit/packet/test_ethernet.py
+++ b/ryu/tests/unit/packet/test_ethernet.py
@@ -58,16 +58,16 @@ class Test_ethernet(unittest.TestCase):
                 return p
 
     def test_init(self):
-        eq_(self.dst, self.e.dst)
-        eq_(self.src, self.e.src)
+        eq_(addrconv.mac.text_to_bin(self.dst), self.e.dst)
+        eq_(addrconv.mac.text_to_bin(self.src), self.e.src)
         eq_(self.ethertype, self.e.ethertype)
 
     def test_parser(self):
         res, ptype, _ = self.e.parser(self.buf)
         LOG.debug((res, ptype))
 
-        eq_(res.dst, self.dst)
-        eq_(res.src, self.src)
+        eq_(res.dst, addrconv.mac.text_to_bin(self.dst))
+        eq_(res.src, addrconv.mac.text_to_bin(self.src))
         eq_(res.ethertype, self.ethertype)
         eq_(ptype, arp)
 

--- a/ryu/tests/unit/packet/test_icmpv6.py
+++ b/ryu/tests/unit/packet/test_icmpv6.py
@@ -36,8 +36,8 @@ LOG = logging.getLogger(__name__)
 
 def icmpv6_csum(prev, buf):
     ph = struct.pack('!16s16sI3xB',
-                     addrconv.ipv6.text_to_bin(prev.src),
-                     addrconv.ipv6.text_to_bin(prev.dst),
+                     prev.src,
+                     prev.dst,
                      prev.payload_length, prev.nxt)
     h = bytearray(buf)
     struct.pack_into('!H', h, 2, 0)

--- a/ryu/tests/unit/packet/test_igmp.py
+++ b/ryu/tests/unit/packet/test_igmp.py
@@ -41,11 +41,11 @@ class Test_igmp(unittest.TestCase):
         self.msgtype = IGMP_TYPE_QUERY
         self.maxresp = 100
         self.csum = 0
-        self.address = '225.0.0.1'
+        self.address = addrconv.ipv4.text_to_bin('225.0.0.1')
 
         self.buf = pack(igmp._PACK_STR, self.msgtype, self.maxresp,
                         self.csum,
-                        addrconv.ipv4.text_to_bin(self.address))
+                        self.address)
 
         self.g = igmp(self.msgtype, self.maxresp, self.csum,
                       self.address)
@@ -86,7 +86,7 @@ class Test_igmp(unittest.TestCase):
         eq_(res[0], self.msgtype)
         eq_(res[1], self.maxresp)
         eq_(res[2], checksum(self.buf))
-        eq_(res[3], addrconv.ipv4.text_to_bin(self.address))
+        eq_(res[3], self.address)
 
     def _build_igmp(self):
         dl_dst = '11:22:33:44:55:66'
@@ -132,7 +132,7 @@ class Test_igmp(unittest.TestCase):
         igmp_values = {'msgtype': repr(self.msgtype),
                        'maxresp': repr(self.maxresp),
                        'csum': repr(self.csum),
-                       'address': repr(self.address)}
+                      }
         _g_str = ','.join(['%s=%s' % (k, igmp_values[k])
                            for k, v in inspect.getmembers(self.g)
                            if k in igmp_values])

--- a/ryu/tests/unit/packet/test_ipv4.py
+++ b/ryu/tests/unit/packet/test_ipv4.py
@@ -49,8 +49,8 @@ class Test_ipv4(unittest.TestCase):
     ttl = 64
     proto = inet.IPPROTO_TCP
     csum = 0xadc6
-    src = '131.151.32.21'
-    dst = '131.151.32.129'
+    src = addrconv.ipv4.text_to_bin('131.151.32.21')
+    dst = addrconv.ipv4.text_to_bin('131.151.32.129')
     length = header_length * 4
     option = '\x86\x28\x00\x00\x00\x01\x01\x22' \
         + '\x00\x01\xae\x00\x00\x00\x00\x00' \
@@ -60,8 +60,8 @@ class Test_ipv4(unittest.TestCase):
 
     buf = pack(ipv4._PACK_STR, ver_hlen, tos, total_length, identification,
                flg_off, ttl, proto, csum,
-               addrconv.ipv4.text_to_bin(src),
-               addrconv.ipv4.text_to_bin(dst)) \
+               src,
+               dst) \
         + option
 
     ip = ipv4(version, header_length, tos, total_length, identification,
@@ -118,8 +118,8 @@ class Test_ipv4(unittest.TestCase):
         eq_(res[4], self.flg_off)
         eq_(res[5], self.ttl)
         eq_(res[6], self.proto)
-        eq_(res[8], addrconv.ipv4.text_to_bin(self.src))
-        eq_(res[9], addrconv.ipv4.text_to_bin(self.dst))
+        eq_(res[8], self.src)
+        eq_(res[9], self.dst)
         eq_(option, self.option)
 
         # checksum

--- a/ryu/tests/unit/packet/test_ipv6.py
+++ b/ryu/tests/unit/packet/test_ipv6.py
@@ -54,8 +54,7 @@ class Test_ipv6(unittest.TestCase):
                        'payload_length': self.payload_length,
                        'nxt': self.nxt,
                        'hop_limit': self.hop_limit,
-                       'src': self.src,
-                       'dst': self.dst}
+                      }
         _ipv6_str = ','.join(['%s=%s' % (k, repr(ipv6_values[k]))
                               for k, v in inspect.getmembers(self.ip)
                               if k in ipv6_values])

--- a/ryu/tests/unit/packet/test_packet.py
+++ b/ryu/tests/unit/packet/test_packet.py
@@ -101,8 +101,8 @@ class TestPacket(unittest.TestCase):
 
         # ethernet
         ok_(p_eth)
-        eq_(self.dst_mac, p_eth.dst)
-        eq_(self.src_mac, p_eth.src)
+        eq_(addrconv.mac.text_to_bin(self.dst_mac), p_eth.dst)
+        eq_(addrconv.mac.text_to_bin(self.src_mac), p_eth.src)
         eq_(ether.ETH_TYPE_ARP, p_eth.ethertype)
 
         # arp
@@ -112,14 +112,14 @@ class TestPacket(unittest.TestCase):
         eq_(6, p_arp.hlen)
         eq_(4, p_arp.plen)
         eq_(2, p_arp.opcode)
-        eq_(self.src_mac, p_arp.src_mac)
-        eq_(self.src_ip, p_arp.src_ip)
-        eq_(self.dst_mac, p_arp.dst_mac)
-        eq_(self.dst_ip, p_arp.dst_ip)
+        eq_(addrconv.mac.text_to_bin(self.src_mac), p_arp.src_mac)
+        eq_(addrconv.ipv4.text_to_bin(self.src_ip), p_arp.src_ip)
+        eq_(addrconv.mac.text_to_bin(self.dst_mac), p_arp.dst_mac)
+        eq_(addrconv.ipv4.text_to_bin(self.dst_ip), p_arp.dst_ip)
 
         # to string
-        eth_values = {'dst': self.dst_mac,
-                      'src': self.src_mac,
+        eth_values = {#'dst': self.dst_mac,
+                      #'src': self.src_mac,
                       'ethertype': ether.ETH_TYPE_ARP}
         _eth_str = ','.join(['%s=%s' % (k, repr(eth_values[k]))
                              for k, v in inspect.getmembers(p_eth)
@@ -131,10 +131,11 @@ class TestPacket(unittest.TestCase):
                       'hlen': 6,
                       'plen': 4,
                       'opcode': 2,
-                      'src_mac': self.src_mac,
-                      'dst_mac': self.dst_mac,
-                      'src_ip': self.src_ip,
-                      'dst_ip': self.dst_ip}
+                      #'src_mac': self.src_mac,
+                      #'dst_mac': self.dst_mac,
+                      #'src_ip': self.src_ip,
+                      #'dst_ip': self.dst_ip
+                      }
         _arp_str = ','.join(['%s=%s' % (k, repr(arp_values[k]))
                              for k, v in inspect.getmembers(p_arp)
                              if k in arp_values])
@@ -197,8 +198,8 @@ class TestPacket(unittest.TestCase):
 
         # ethernet
         ok_(p_eth)
-        eq_(self.dst_mac, p_eth.dst)
-        eq_(self.src_mac, p_eth.src)
+        eq_(addrconv.mac.text_to_bin(self.dst_mac), p_eth.dst)
+        eq_(addrconv.mac.text_to_bin(self.src_mac), p_eth.src)
         eq_(ether.ETH_TYPE_8021Q, p_eth.ethertype)
 
         # vlan
@@ -215,14 +216,14 @@ class TestPacket(unittest.TestCase):
         eq_(6, p_arp.hlen)
         eq_(4, p_arp.plen)
         eq_(2, p_arp.opcode)
-        eq_(self.src_mac, p_arp.src_mac)
-        eq_(self.src_ip, p_arp.src_ip)
-        eq_(self.dst_mac, p_arp.dst_mac)
-        eq_(self.dst_ip, p_arp.dst_ip)
+        eq_(addrconv.mac.text_to_bin(self.src_mac), p_arp.src_mac)
+        eq_(addrconv.ipv4.text_to_bin(self.src_ip), p_arp.src_ip)
+        eq_(addrconv.mac.text_to_bin(self.dst_mac), p_arp.dst_mac)
+        eq_(addrconv.ipv4.text_to_bin(self.dst_ip), p_arp.dst_ip)
 
         # to string
-        eth_values = {'dst': self.dst_mac,
-                      'src': self.src_mac,
+        eth_values = {#'dst': self.dst_mac,
+                      #'src': self.src_mac,
                       'ethertype': ether.ETH_TYPE_8021Q}
         _eth_str = ','.join(['%s=%s' % (k, repr(eth_values[k]))
                              for k, v in inspect.getmembers(p_eth)
@@ -243,10 +244,11 @@ class TestPacket(unittest.TestCase):
                       'hlen': 6,
                       'plen': 4,
                       'opcode': 2,
-                      'src_mac': self.src_mac,
-                      'dst_mac': self.dst_mac,
-                      'src_ip': self.src_ip,
-                      'dst_ip': self.dst_ip}
+                      #'src_mac': self.src_mac,
+                      #'dst_mac': self.dst_mac,
+                      #'src_ip': self.src_ip,
+                      #'dst_ip': self.dst_ip
+                      }
         _arp_str = ','.join(['%s=%s' % (k, repr(arp_values[k]))
                              for k, v in inspect.getmembers(p_arp)
                              if k in arp_values])
@@ -315,8 +317,8 @@ class TestPacket(unittest.TestCase):
 
         # ethernet
         ok_(p_eth)
-        eq_(self.dst_mac, p_eth.dst)
-        eq_(self.src_mac, p_eth.src)
+        eq_(addrconv.mac.text_to_bin(self.dst_mac), p_eth.dst)
+        eq_(addrconv.mac.text_to_bin(self.src_mac), p_eth.src)
         eq_(ether.ETH_TYPE_IP, p_eth.ethertype)
 
         # ipv4
@@ -330,8 +332,8 @@ class TestPacket(unittest.TestCase):
         eq_(1, p_ipv4.flags)
         eq_(64, p_ipv4.ttl)
         eq_(inet.IPPROTO_UDP, p_ipv4.proto)
-        eq_(self.src_ip, p_ipv4.src)
-        eq_(self.dst_ip, p_ipv4.dst)
+        eq_(addrconv.ipv4.text_to_bin(self.src_ip), p_ipv4.src)
+        eq_(addrconv.ipv4.text_to_bin(self.dst_ip), p_ipv4.dst)
         t = bytearray(ip_buf)
         struct.pack_into('!H', t, 10, p_ipv4.csum)
         eq_(packet_utils.checksum(t), 0)
@@ -354,8 +356,8 @@ class TestPacket(unittest.TestCase):
         eq_(self.payload, protocols['payload'].tostring())
 
         # to string
-        eth_values = {'dst': self.dst_mac,
-                      'src': self.src_mac,
+        eth_values = {#'dst': self.dst_mac,
+                      #'src': self.src_mac,
                       'ethertype': ether.ETH_TYPE_IP}
         _eth_str = ','.join(['%s=%s' % (k, repr(eth_values[k]))
                              for k, v in inspect.getmembers(p_eth)
@@ -372,8 +374,8 @@ class TestPacket(unittest.TestCase):
                        'ttl': 64,
                        'proto': inet.IPPROTO_UDP,
                        'csum': p_ipv4.csum,
-                       'src': self.src_ip,
-                       'dst': self.dst_ip,
+                       #'src': self.src_ip,
+                       #'dst': self.dst_ip,
                        'option': None}
         _ipv4_str = ','.join(['%s=%s' % (k, repr(ipv4_values[k]))
                               for k, v in inspect.getmembers(p_ipv4)
@@ -460,8 +462,8 @@ class TestPacket(unittest.TestCase):
 
         # ethernet
         ok_(p_eth)
-        eq_(self.dst_mac, p_eth.dst)
-        eq_(self.src_mac, p_eth.src)
+        eq_(addrconv.mac.text_to_bin(self.dst_mac), p_eth.dst)
+        eq_(addrconv.mac.text_to_bin(self.src_mac), p_eth.src)
         eq_(ether.ETH_TYPE_IP, p_eth.ethertype)
 
         # ipv4
@@ -475,8 +477,8 @@ class TestPacket(unittest.TestCase):
         eq_(0, p_ipv4.flags)
         eq_(64, p_ipv4.ttl)
         eq_(inet.IPPROTO_TCP, p_ipv4.proto)
-        eq_(self.src_ip, p_ipv4.src)
-        eq_(self.dst_ip, p_ipv4.dst)
+        eq_(addrconv.ipv4.text_to_bin(self.src_ip), p_ipv4.src)
+        eq_(addrconv.ipv4.text_to_bin(self.dst_ip), p_ipv4.dst)
         t = bytearray(ip_buf)
         struct.pack_into('!H', t, 10, p_ipv4.csum)
         eq_(packet_utils.checksum(t), 0)
@@ -504,8 +506,8 @@ class TestPacket(unittest.TestCase):
         eq_(self.payload, protocols['payload'].tostring())
 
         # to string
-        eth_values = {'dst': self.dst_mac,
-                      'src': self.src_mac,
+        eth_values = {#'dst': self.dst_mac,
+                      #'src': self.src_mac,
                       'ethertype': ether.ETH_TYPE_IP}
         _eth_str = ','.join(['%s=%s' % (k, repr(eth_values[k]))
                              for k, v in inspect.getmembers(p_eth)
@@ -522,8 +524,8 @@ class TestPacket(unittest.TestCase):
                        'ttl': 64,
                        'proto': inet.IPPROTO_TCP,
                        'csum': p_ipv4.csum,
-                       'src': self.src_ip,
-                       'dst': self.dst_ip,
+                       #'src': self.src_ip,
+                       #'dst': self.dst_ip,
                        'option': None}
         _ipv4_str = ','.join(['%s=%s' % (k, repr(ipv4_values[k]))
                               for k, v in inspect.getmembers(p_ipv4)
@@ -620,8 +622,8 @@ class TestPacket(unittest.TestCase):
 
         # ethernet
         ok_(p_eth)
-        eq_(self.dst_mac, p_eth.dst)
-        eq_(self.src_mac, p_eth.src)
+        eq_(addrconv.mac.text_to_bin(self.dst_mac), p_eth.dst)
+        eq_(addrconv.mac.text_to_bin(self.src_mac), p_eth.src)
         eq_(ether.ETH_TYPE_IEEE802_3, p_eth.ethertype)
 
         # llc
@@ -640,11 +642,11 @@ class TestPacket(unittest.TestCase):
         eq_(0, p_bpdu.flags)
         eq_(32768, p_bpdu.root_priority)
         eq_(0, p_bpdu.root_system_id_extension)
-        eq_(self.src_mac, p_bpdu.root_mac_address)
+        eq_(addrconv.mac.text_to_bin(self.src_mac), p_bpdu.root_mac_address)
         eq_(0, p_bpdu.root_path_cost)
         eq_(32768, p_bpdu.bridge_priority)
         eq_(0, p_bpdu.bridge_system_id_extension)
-        eq_(self.dst_mac, p_bpdu.bridge_mac_address)
+        eq_(addrconv.mac.text_to_bin(self.dst_mac), p_bpdu.bridge_mac_address)
         eq_(128, p_bpdu.port_priority)
         eq_(4, p_bpdu.port_number)
         eq_(1, p_bpdu.message_age)
@@ -653,8 +655,8 @@ class TestPacket(unittest.TestCase):
         eq_(15, p_bpdu.forward_delay)
 
         # to string
-        eth_values = {'dst': self.dst_mac,
-                      'src': self.src_mac,
+        eth_values = {#'dst': self.dst_mac,
+                      #'src': self.src_mac,
                       'ethertype': ether.ETH_TYPE_IEEE802_3}
         _eth_str = ','.join(['%s=%s' % (k, repr(eth_values[k]))
                              for k, v in inspect.getmembers(p_eth)
@@ -683,11 +685,11 @@ class TestPacket(unittest.TestCase):
                        'flags': 0,
                        'root_priority': long(32768),
                        'root_system_id_extension': long(0),
-                       'root_mac_address': self.src_mac,
+                       #'root_mac_address': self.src_mac,
                        'root_path_cost': 0,
                        'bridge_priority': long(32768),
                        'bridge_system_id_extension': long(0),
-                       'bridge_mac_address': self.dst_mac,
+                       #'bridge_mac_address': self.dst_mac,
                        'port_priority': 128,
                        'port_number': 4,
                        'message_age': float(1),

--- a/ryu/tests/unit/packet/test_slow.py
+++ b/ryu/tests/unit/packet/test_slow.py
@@ -41,7 +41,7 @@ class Test_slow(unittest.TestCase):
         self.actor_tag = lacp.LACP_TLV_TYPE_ACTOR
         self.actor_length = 20
         self.actor_system_priority = 65534
-        self.actor_system = '00:07:0d:af:f4:54'
+        self.actor_system = addrconv.mac.text_to_bin('00:07:0d:af:f4:54')
         self.actor_key = 1
         self.actor_port_priority = 65535
         self.actor_port = 1
@@ -65,7 +65,7 @@ class Test_slow(unittest.TestCase):
         self.partner_tag = lacp.LACP_TLV_TYPE_PARTNER
         self.partner_length = 20
         self.partner_system_priority = 0
-        self.partner_system = '00:00:00:00:00:00'
+        self.partner_system = addrconv.mac.text_to_bin('00:00:00:00:00:00')
         self.partner_key = 0
         self.partner_port_priority = 0
         self.partner_port = 0
@@ -167,7 +167,7 @@ class Test_lacp(unittest.TestCase):
         self.actor_tag = lacp.LACP_TLV_TYPE_ACTOR
         self.actor_length = 20
         self.actor_system_priority = 65534
-        self.actor_system = '00:07:0d:af:f4:54'
+        self.actor_system = addrconv.mac.text_to_bin('00:07:0d:af:f4:54')
         self.actor_key = 1
         self.actor_port_priority = 65535
         self.actor_port = 1
@@ -191,7 +191,7 @@ class Test_lacp(unittest.TestCase):
         self.partner_tag = lacp.LACP_TLV_TYPE_PARTNER
         self.partner_length = 20
         self.partner_system_priority = 0
-        self.partner_system = '00:00:00:00:00:00'
+        self.partner_system = addrconv.mac.text_to_bin('00:00:00:00:00:00')
         self.partner_key = 0
         self.partner_port_priority = 0
         self.partner_port = 0
@@ -237,7 +237,7 @@ class Test_lacp(unittest.TestCase):
                             self.actor_tag,
                             self.actor_length,
                             self.actor_system_priority,
-                            addrconv.mac.text_to_bin(self.actor_system),
+                            self.actor_system,
                             self.actor_key,
                             self.actor_port_priority,
                             self.actor_port,
@@ -246,7 +246,7 @@ class Test_lacp(unittest.TestCase):
                             self.partner_tag,
                             self.partner_length,
                             self.partner_system_priority,
-                            addrconv.mac.text_to_bin(self.partner_system),
+                            self.partner_system,
                             self.partner_key,
                             self.partner_port_priority,
                             self.partner_port,
@@ -423,7 +423,7 @@ class Test_lacp(unittest.TestCase):
         eq_(act_res[0], self.actor_tag)
         eq_(act_res[1], self.actor_length)
         eq_(act_res[2], self.actor_system_priority)
-        eq_(act_res[3], addrconv.mac.text_to_bin(self.actor_system))
+        eq_(act_res[3], self.actor_system)
         eq_(act_res[4], self.actor_key)
         eq_(act_res[5], self.actor_port_priority)
         eq_(act_res[6], self.actor_port)
@@ -432,7 +432,7 @@ class Test_lacp(unittest.TestCase):
         eq_(prt_res[0], self.partner_tag)
         eq_(prt_res[1], self.partner_length)
         eq_(prt_res[2], self.partner_system_priority)
-        eq_(prt_res[3], addrconv.mac.text_to_bin(self.partner_system))
+        eq_(prt_res[3], self.partner_system)
         eq_(prt_res[4], self.partner_key)
         eq_(prt_res[5], self.partner_port_priority)
         eq_(prt_res[6], self.partner_port)

--- a/ryu/tests/unit/packet/test_vrrp.py
+++ b/ryu/tests/unit/packet/test_vrrp.py
@@ -47,7 +47,7 @@ class Test_vrrpv2(unittest.TestCase):
     auth_type = vrrp.VRRP_AUTH_NO_AUTH
     max_adver_int = 100
     checksum = 0
-    ip_address = '192.168.0.1'
+    ip_address = addrconv.ipv4.text_to_bin('192.168.0.1')
     auth_data = (0, 0)
     vrrpv2 = vrrp.vrrpv2.create(type_, vrid, priority, max_adver_int,
                                 [ip_address])
@@ -55,7 +55,7 @@ class Test_vrrpv2(unittest.TestCase):
                       vrrp.vrrp_to_version_type(vrrp.VRRP_VERSION_V2, type_),
                       vrid, priority, count_ip,
                       auth_type, max_adver_int, checksum,
-                      addrconv.ipv4.text_to_bin(ip_address),
+                      ip_address,
                       auth_data[0], auth_data[1])
 
     def setUp(self):
@@ -192,7 +192,6 @@ class Test_vrrpv2(unittest.TestCase):
                          'count_ip': self.count_ip,
                          'max_adver_int': self.max_adver_int,
                          'checksum': self.vrrpv2.checksum,
-                         'ip_addresses': [self.ip_address],
                          'auth_type': self.auth_type,
                          'auth_data': self.auth_data,
                          'identification': self.vrrpv2.identification}
@@ -215,14 +214,14 @@ class Test_vrrpv3_ipv4(unittest.TestCase):
     count_ip = 1
     max_adver_int = 111
     checksum = 0
-    ip_address = '192.168.0.1'
+    ip_address = addrconv.ipv4.text_to_bin('192.168.0.1')
     vrrpv3 = vrrp.vrrpv3.create(type_, vrid, priority, max_adver_int,
                                 [ip_address])
     buf = struct.pack(vrrp.vrrpv3._PACK_STR + '4s',
                       vrrp.vrrp_to_version_type(vrrp.VRRP_VERSION_V3, type_),
                       vrid, priority, count_ip,
                       max_adver_int, checksum,
-                      addrconv.ipv4.text_to_bin(ip_address))
+                      ip_address)
 
     def setUp(self):
         pass
@@ -357,7 +356,6 @@ class Test_vrrpv3_ipv4(unittest.TestCase):
                          'count_ip': self.count_ip,
                          'max_adver_int': self.max_adver_int,
                          'checksum': self.vrrpv3.checksum,
-                         'ip_addresses': [self.ip_address],
                          'auth_type': None,
                          'auth_data': None,
                          'identification': self.vrrpv3.identification}
@@ -401,7 +399,7 @@ class Test_vrrpv3_ipv6(unittest.TestCase):
         eq_(self.priority, self.vrrpv3.priority)
         eq_(self.count_ip, self.vrrpv3.count_ip)
         eq_(1, len(self.vrrpv3.ip_addresses))
-        eq_(self.ip_address, self.vrrpv3.ip_addresses[0])
+        eq_(self.ip_address, addrconv.ipv6.bin_to_text(self.vrrpv3.ip_addresses[0]))
 
     def test_parser(self):
         vrrpv3, _cls, _ = self.vrrpv3.parser(self.buf)
@@ -415,10 +413,10 @@ class Test_vrrpv3_ipv6(unittest.TestCase):
         eq_(self.checksum, vrrpv3.checksum)
         eq_(1, len(vrrpv3.ip_addresses))
         eq_(str, type(vrrpv3.ip_addresses[0]))
-        eq_(self.ip_address, vrrpv3.ip_addresses[0])
+        eq_(self.ip_address, addrconv.ipv6.bin_to_text(vrrpv3.ip_addresses[0]))
 
     def test_serialize(self):
-        src_ip = '2001:db8:2000::1'
+        src_ip = '2001:db8:2000::10'
         dst_ip = vrrp.VRRP_IPV6_DST_ADDRESS
         prev = ipv6.ipv6(6, 0, 0, 0, inet.IPPROTO_VRRP,
                          vrrp.VRRP_IPV6_HOP_LIMIT, src_ip, dst_ip)
@@ -427,7 +425,7 @@ class Test_vrrpv3_ipv6(unittest.TestCase):
         vrid = 5
         priority = 10
         max_adver_int = 30
-        ip_address = '2001:db8:2000::2'
+        ip_address = '2001:db8:2000::20'
         ip_addresses = [ip_address]
 
         vrrp_ = vrrp.vrrpv3.create(
@@ -480,7 +478,6 @@ class Test_vrrpv3_ipv6(unittest.TestCase):
                          'count_ip': self.count_ip,
                          'max_adver_int': self.max_adver_int,
                          'checksum': self.vrrpv3.checksum,
-                         'ip_addresses': [self.ip_address],
                          'auth_type': None,
                          'auth_data': None,
                          'identification': self.vrrpv3.identification}


### PR DESCRIPTION
They are not automatically translated into human readable format anymore , as this was introducing a lot of overhead.

http://www.mail-archive.com/ryu-devel@lists.sourceforge.net/msg04213.html

Now Ryu has comparable performance against dpkt. It is only 15~20% slower on unpacking, and 2 times slower on packing a packet. ( Down from 500% and 700% )
