### PR TITLE
update bgp open message capability code of 128

### DIFF
--- a/ryu/lib/packet/bgp.py
+++ b/ryu/lib/packet/bgp.py
@@ -53,6 +53,9 @@ BGP_CAP_CARRYING_LABEL_INFO = 4  # RFC 3107
 BGP_CAP_FOUR_OCTET_AS_NUMBER = 65  # RFC 4893
 BGP_CAP_ENHANCED_ROUTE_REFRESH = 70  # https://tools.ietf.org/html/\
 # draft-ietf-idr-bgp-enhanced-route-refresh-05
+BGP_CAP_ROUTE_REFRESH_CISCO = 128
+# in cisco routers, there are two route refresh code: one using the capability code of 128 (old),
+# another using the capability code of 2 (new).
 
 BGP_ATTR_FLAG_OPTIONAL = 1 << 7
 BGP_ATTR_FLAG_TRANSITIVE = 1 << 6
@@ -1178,6 +1181,11 @@ class BGPOptParamCapabilityUnknown(_OptParamCapability):
 
 @_OptParamCapability.register_type(BGP_CAP_ROUTE_REFRESH)
 class BGPOptParamCapabilityRouteRefresh(_OptParamEmptyCapability):
+    pass
+
+
+@_OptParamCapability.register_type(BGP_CAP_ROUTE_REFRESH_CISCO)
+class BGPOptParamCapabilityCiscoRouteRefresh(_OptParamEmptyCapability):
     pass
 
 

--- a/ryu/tests/unit/packet/test_bgp.py
+++ b/ryu/tests/unit/packet/test_bgp.py
@@ -45,6 +45,7 @@ class Test_bgp(unittest.TestCase):
         opt_param = [bgp.BGPOptParamCapabilityUnknown(cap_code=200,
                                                       cap_value='hoge'),
                      bgp.BGPOptParamCapabilityRouteRefresh(),
+                     bgp.BGPOptParamCapabilityCiscoRouteRefresh(),
                      bgp.BGPOptParamCapabilityMultiprotocol(
                          afi=afi.IP, safi=safi.MPLS_VPN),
                      bgp.BGPOptParamCapabilityCarryingLabelInfo(),


### PR DESCRIPTION
hi team

I write a patch about bgp open message capacity code type =128?

and this is a cisco old route refresh

and wireshark can decode this too
