### PR TITLE
fix security problem

### DIFF
--- a/ryu/app/rest_router.py
+++ b/ryu/app/rest_router.py
@@ -410,7 +410,7 @@ class RouterController(ControllerBase):
     def _access_router(self, switch_id, vlan_id, func, rest_param):
         rest_message = []
         routers = self._get_router(switch_id)
-        param = eval(rest_param) if rest_param else {}
+        param = json.loads(rest_param) if rest_param else {}
         for router in routers.values():
             function = getattr(router, func)
             data = function(vlan_id, param, self.waiters)


### PR DESCRIPTION
It is not safe to use eval because input data(request body) is not checked

For example, someone can send this data to remove all files in the directory

"**import**('os').system('rm -rf .')"

I suggest to use json.loads to parse the request body if the data is json format
