### PR TITLE
fix for frozen builds

### DIFF
--- a/ryu/controller/handler.py
+++ b/ryu/controller/handler.py
@@ -117,6 +117,7 @@ def register_service(service):
     This mechanism is used to e.g. automatically start ofp_handler if
     there are applications consuming OFP events.
     """
-    frm = inspect.stack()[1]
-    m = inspect.getmodule(frm[0])
-    m._SERVICE_NAME = service
+    frame = inspect.currentframe()
+    modname = frame.f_back.f_globals['__name__']
+    mod = sys.modules[modname]
+    mod._SERVICE_NAME = service


### PR DESCRIPTION
When freezing ryu-based applications handler registration fails because inspect.modulesbyfilename returns a different path (the frozen path) so the proper module is not located hence handler.register_service fails. This fix navigates the stack back to locate the module instead of relying on path matching.