### PR TITLE
fix security problem

### DIFF
--- a/ryu/app/ofctl_rest.py
+++ b/ryu/app/ofctl_rest.py
@@ -155,7 +155,7 @@ class StatsController(ControllerBase):
             flow = {}
         else:
             try:
-                flow = eval(req.body)
+                flow = json.loads(req.body)
             except SyntaxError:
                 LOG.debug('invalid syntax %s', req.body)
                 return Response(status=400)
@@ -326,7 +326,7 @@ class StatsController(ControllerBase):
 
     def mod_flow_entry(self, req, cmd, **_kwargs):
         try:
-            flow = eval(req.body)
+            flow = json.loads(req.body)
         except SyntaxError:
             LOG.debug('invalid syntax %s', req.body)
             return Response(status=400)
@@ -380,7 +380,7 @@ class StatsController(ControllerBase):
 
     def mod_meter_entry(self, req, cmd, **_kwargs):
         try:
-            flow = eval(req.body)
+            flow = json.loads(req.body)
         except SyntaxError:
             LOG.debug('invalid syntax %s', req.body)
             return Response(status=400)
@@ -413,7 +413,7 @@ class StatsController(ControllerBase):
 
     def mod_group_entry(self, req, cmd, **_kwargs):
         try:
-            group = eval(req.body)
+            group = json.loads(req.body)
         except SyntaxError:
             LOG.debug('invalid syntax %s', req.body)
             return Response(status=400)
@@ -448,7 +448,7 @@ class StatsController(ControllerBase):
 
     def mod_port_behavior(self, req, cmd, **_kwargs):
         try:
-            port_config = eval(req.body)
+            port_config = json.loads(req.body)
         except SyntaxError:
             LOG.debug('invalid syntax %s', req.body)
             return Response(status=400)
@@ -493,7 +493,7 @@ class StatsController(ControllerBase):
             return Response(status=404)
 
         try:
-            exp = eval(req.body)
+            exp = json.loads(req.body)
         except SyntaxError:
             LOG.debug('invalid syntax %s', req.body)
             return Response(status=400)

--- a/ryu/app/rest_firewall.py
+++ b/ryu/app/rest_firewall.py
@@ -492,7 +492,7 @@ class FirewallController(ControllerBase):
 
     def _set_rule(self, req, switchid, vlan_id=VLANID_NONE):
         try:
-            rule = eval(req.body)
+            rule = json.loads(req.body)
         except SyntaxError:
             FirewallController._LOGGER.debug('invalid syntax %s', req.body)
             return Response(status=400)
@@ -516,7 +516,7 @@ class FirewallController(ControllerBase):
 
     def _delete_rule(self, req, switchid, vlan_id=VLANID_NONE):
         try:
-            ruleid = eval(req.body)
+            ruleid = json.loads(req.body)
         except SyntaxError:
             FirewallController._LOGGER.debug('invalid syntax %s', req.body)
             return Response(status=400)

--- a/ryu/app/rest_qos.py
+++ b/ryu/app/rest_qos.py
@@ -499,7 +499,7 @@ class QoSController(ControllerBase):
 
     def _access_switch(self, req, switchid, vlan_id, func, waiters):
         try:
-            rest = eval(req.body) if req.body else {}
+            rest = json.loads(req.body) if req.body else {}
         except SyntaxError:
             QoSController._LOGGER.debug('invalid syntax %s', req.body)
             return Response(status=400)


### PR DESCRIPTION
It is not safe to use eval function because input data(request body) is not checked

For example, someone can send this data to remove all files in the directory

"import('os').system('rm -rf .')"

I suggest to use json.loads to parse the request body if the data is json format

or disable builtin functions like:

eval(req.body, {"__builtins__":None})