### PR TITLE
Workaround os.path.samefile absence on Windows

### DIFF
--- a/ryu/utils.py
+++ b/ryu/utils.py
@@ -48,7 +48,7 @@ def chop_py_suffix(p):
 
 def _likely_same(a, b):
     try:
-         # Samefile not availible on windows
+        # Samefile not availible on windows
         if sys.platform == 'win32':
             if os.stat(a) == os.stat(b):
                 return True


### PR DESCRIPTION
When trying out ryu under windows (and Python 2.7) I ran into a error because os.path.samefile is not implemented. I did a quick workaround in ryu/utils.py to use the os.stat(file) output instead if on the "win32" platform.

Change seems to allow application to run on Windows and change built clean on Travis.
