### PR TITLE
disable padding check for llc supervisory packets

### DIFF
--- a/ryu/lib/packet/llc.py
+++ b/ryu/lib/packet/llc.py
@@ -250,7 +250,7 @@ class ControlFormatS(stringify.StringifyMixin):
         (control,) = struct.unpack_from(cls._PACK_STR, buf)
 
         assert (control >> 8) & 0b11 == cls.TYPE
-        assert (control >> 12) & 0b1111 == 0
+        #assert (control >> 12) & 0b1111 == 0
 
         supervisory_function = (control >> 10) & 0b11
         pf_bit = (control >> 8) & 0b1


### PR DESCRIPTION
the llc padding check causes an exception when android or iOS devices are used (dhcp).

I tried to connect an android and iOS device to an access point which is ovs enabled. The ovs is connected to ryu.

When the UE is trying to attach it generates an LLC message (Supervisory frame). In this frame the padding bits (5-8) are set to 1. The IEEE 802.2 (https://standards.ieee.org/getieee802/download/802.2-1998.pdf page 46) describes that it should be set to 0.

I understand that the IEEE specification is the "law", but every first time I connect those devices ryu is causing an exception.

iOS device:
![llc_pull_request_1](https://cloud.githubusercontent.com/assets/3919401/7229852/a32cbabc-e768-11e4-98e9-f5c7c306cd76.png)
Android device:
![llc_pull_request_2](https://cloud.githubusercontent.com/assets/3919401/7229853/a32cd7c2-e768-11e4-811d-4b332224d51c.png)

