### PR TITLE
Fix: enable ipv6 for ovsdb connection

### DIFF
--- a/ryu/contrib/ovs/stream.py
+++ b/ryu/contrib/ovs/stream.py
@@ -354,8 +354,7 @@ Stream.register_method("unix", UnixStream)
 class TCPStream(Stream):
     @staticmethod
     def _open(suffix, dscp):
-        error, sock = ovs.socket_util.inet_open_active(socket.SOCK_STREAM,
-                                                       suffix, 0, dscp)
+        error, sock = ovs.socket_util.inet_open_active_stream(suffix, 0, dscp)
         if not error:
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         return error, sock


### PR DESCRIPTION
an ipv6 connection with an ovsdb server was not possible, because inet_open_active used AF_INET as constant. 