### PR TITLE
Fix example app launch / dependency calculation under Python 3

### DIFF
--- a/ryu/base/app_manager.py
+++ b/ryu/base/app_manager.py
@@ -77,11 +77,12 @@ def require_app(app_name, api_style=False):
 
     If this is used for client application module, set api_style=False.
     """
+    iterable = (inspect.getmodule(frame[0]) for frame in inspect.stack())
+    modules = [module for module in iterable if module is not None]
     if api_style:
-        frm = inspect.stack()[2]  # skip a frame for "api" module
+        m = modules[2]  # skip a frame for "api" module
     else:
-        frm = inspect.stack()[1]
-    m = inspect.getmodule(frm[0])  # client module
+        m = modules[1]
     m._REQUIRED_APP = getattr(m, '_REQUIRED_APP', [])
     m._REQUIRED_APP.append(app_name)
     LOG.debug('require_app: %s is required by %s', app_name, m.__name__)

--- a/ryu/controller/handler.py
+++ b/ryu/controller/handler.py
@@ -86,9 +86,13 @@ def register_instance(i):
                 i.register_handler(ev_cls, m)
 
 
+def _is_method(f):
+    return inspect.isfunction(f) or inspect.ismethod(f) 
+
+
 def get_dependent_services(cls):
     services = []
-    for _k, m in inspect.getmembers(cls, inspect.ismethod):
+    for _k, m in inspect.getmembers(cls, _is_method):
         if _has_caller(m):
             for ev_cls, c in m.callers.items():
                 service = getattr(sys.modules[ev_cls.__module__],


### PR DESCRIPTION
This PR restores the example applications within the app/* directory to a working condition under Python 3, with the exception of those depending on the OVS bindings (Which haven't been ported to 3.x yet)
