### PR TITLE
Fix: "AddrFormatError: address '...' is not an EUIv48"

### DIFF
--- a/ryu/ofproto/ofproto_v1_0_parser.py
+++ b/ryu/ofproto/ofproto_v1_0_parser.py
@@ -21,6 +21,7 @@ Decoder/Encoder implementations of OpenFlow 1.0.
 import struct
 import binascii
 import six
+import netaddr
 
 from ryu.ofproto.ofproto_parser import StringifyMixin, MsgBase
 from ryu.lib import addrconv
@@ -214,7 +215,7 @@ class OFPMatch(StringifyMixin):
             self.dl_src = mac.DONTCARE
         else:
             wc &= ~ofproto.OFPFW_DL_SRC
-            if isinstance(dl_src, (six.text_type, str)) and ':' in dl_src:
+            if isinstance(dl_src, (six.text_type, str)) and netaddr.valid_mac(dl_src):
                 dl_src = addrconv.mac.text_to_bin(dl_src)
             if dl_src == 0:
                 self.dl_src = mac.DONTCARE
@@ -225,7 +226,7 @@ class OFPMatch(StringifyMixin):
             self.dl_dst = mac.DONTCARE
         else:
             wc &= ~ofproto.OFPFW_DL_DST
-            if isinstance(dl_dst, (six.text_type, str)) and ':' in dl_dst:
+            if isinstance(dl_dst, (six.text_type, str)) and netaddr.valid_mac(dl_dst):
                 dl_dst = addrconv.mac.text_to_bin(dl_dst)
             if dl_dst == 0:
                 self.dl_dst = mac.DONTCARE
@@ -517,7 +518,7 @@ class OFPActionStripVlan(OFPAction):
 class OFPActionDlAddr(OFPAction):
     def __init__(self, dl_addr):
         super(OFPActionDlAddr, self).__init__()
-        if isinstance(dl_addr, (six.text_type, str)) and ':' in dl_addr:
+        if isinstance(dl_addr, (six.text_type, str)) and netaddr.valid_mac(dl_addr):
             dl_addr = addrconv.mac.text_to_bin(dl_addr)
         self.dl_addr = dl_addr
 


### PR DESCRIPTION
OFPMatch failed when provided with an already encoded MAC source or destination that contains the octet 0x38 (ASCII: ':') due to improper address format detection.