### PR TITLE
doc: specify OFP v1.0 for sample application

### DIFF
--- a/doc/source/writing_ryu_app.rst
+++ b/doc/source/writing_ryu_app.rst
@@ -53,8 +53,11 @@ the ports.
    from ryu.controller import ofp_event
    from ryu.controller.handler import MAIN_DISPATCHER
    from ryu.controller.handler import set_ev_cls
+   from ryu.ofproto import ofproto_v1_0
    
    class L2Switch(app_manager.RyuApp):
+       OFP_VERSIONS = [ofproto_v1_0.OFP_VERSION]
+
        def __init__(self, *args, **kwargs):
            super(L2Switch, self).__init__(*args, **kwargs)
    


### PR DESCRIPTION
This is a minimal change to keep the supplied sample code
working with latest software. The sample code is not compatible
with OFP v1.3+, and if there is no requirement on supported version
Ryu will probably accept latest supported OF switch.