### PR TITLE
added oxm field for match on ttl

### DIFF
--- a/ryu/ofproto/nicira_ext.py
+++ b/ryu/ofproto/nicira_ext.py
@@ -487,6 +487,11 @@ oxm_types = [
     oxm_fields.NiciraExtended0('vlan_tci', 4, type_desc.Int2),
     oxm_fields.NiciraExtended0('ip_proto_nxm', 6, type_desc.Int1),
     oxm_fields.NiciraExtended1('tunnel_id_nxm', 16, type_desc.Int8),
+
+    #ttl match 
+    oxm_fields.NiciraExtended1('nw_ttl_nxm', 29, type_desc.Int1),
+
+
     oxm_fields.NiciraExtended1('tun_ipv4_src', 31, type_desc.IPv4Addr),
     oxm_fields.NiciraExtended1('tun_ipv4_dst', 32, type_desc.IPv4Addr),
     oxm_fields.NiciraExtended1('pkt_mark', 33, type_desc.Int4),


### PR DESCRIPTION
Hello, I needed the match on IP ttl for a project I'm working on. It was simple to add so I wanted to contribute back the modification.

The ovs-filed I was using is NXM_NX_IP_TTL. There was some discussion in the mailing list about adding support for it, and the framwork supports it, this little code snippet was needed to be able to craft an OFPMatch with the ttl rule. 

I've tested it in my test env and it does produce the required ttl match rules in my OVS. 