### PR TITLE
fix ovsdb:api:set_controller bug

### DIFF
--- a/ryu/services/protocols/ovsdb/api.py
+++ b/ryu/services/protocols/ovsdb/api.py
@@ -363,7 +363,7 @@ def del_port_by_name(manager, system_id, bridge_name, port_name):
 
 
 def set_controller(manager, system_id, bridge_name,
-                   target, controller_info=None):
+                   target, controller_info=dict()):
     def _set_controller(tables, insert):
         bridge = _get_bridge(tables, bridge_name)
 


### PR DESCRIPTION
Line 373:             _uuid = controller_info.get('uuid', uuid.uuid4())
AttributeError: 'NoneType' object has no attribute 'get'