### PR TITLE
Only import pip if needed

### DIFF
--- a/ryu/utils.py
+++ b/ryu/utils.py
@@ -20,8 +20,6 @@ import os
 import sys
 
 import six
-from pip import req as pip_req
-from pip.download import PipSession
 
 
 LOG = logging.getLogger('ryu.utils')
@@ -142,6 +140,9 @@ def parse_requirements(requirements_files=None):
      is ['requirements.txt', 'tools/pip-requires'].
     :return: List of requirements.
     """
+    from pip import req as pip_req
+    from pip.download import PipSession
+
     requirements_files = requirements_files or [
         'requirements.txt',
         'tools/pip-requires',


### PR DESCRIPTION
In some systems pip is not installed and the parse_requirements() function
is not needed. So only import pip if needed. Otherwise this fails with:

  from ryu.base import app_manager
  File "/usr/lib/python2.7/site-packages/ryu/base/app_manager.py", line 34, in <module>
  from ryu import utils
  File "/usr/lib/python2.7/site-packages/ryu/utils.py", line 23, in <module>
  from pip import req as pip_req
  ImportError: No module named pip