### PR TITLE
allow versions of eventlet > 0.21.0

### DIFF
--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -1,7 +1,7 @@
-# NOTE: OpenStack avoids the newer versions of eventlet, because of the
+# NOTE: OpenStack avoids some versions of eventlet, because of the
 # following issue.
 # https://github.com/eventlet/eventlet/issues/401
-eventlet!=0.18.3,>=0.18.2,!=0.20.1,<0.21.0
+eventlet!=0.18.3,>=0.18.2,!=0.20.1,!=0.21.0
 msgpack>=0.3.0  # RPC library, BGP speaker(net_cntl)
 netaddr
 oslo.config>=1.15.0


### PR DESCRIPTION
given https://github.com/eventlet/eventlet/issues/401 has been closed / fixed in eventlet 0.22, it seems that ryu should acceptably work with this version. sending a note to the mailing list in tandem.