### PR TITLE
Restrict tinyrpc to version 0.9.4 as newer versions break python2 support

### DIFF
--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -8,5 +8,5 @@ oslo.config>=2.5.0
 ovs>=2.6.0  # OVSDB
 routes  # wsgi
 six>=1.4.0
-tinyrpc  # RPC library, BGP speaker(net_cntl)
+tinyrpc==0.9.4  # RPC library, BGP speaker(net_cntl)
 webob>=1.2  # wsgi


### PR DESCRIPTION
Tinyrpc dropped python2.7 support in verison 1.0.0.
Version 0.9.4 is the last version to support python2.7, therefor ryu should use that version until it itself drops python2.7 support.