### PR TITLE
Update simple_switch_igmp.py

### DIFF
--- a/ryu/app/simple_switch_igmp.py
+++ b/ryu/app/simple_switch_igmp.py
@@ -22,6 +22,7 @@ from ryu.ofproto import ofproto_v1_0
 from ryu.lib import addrconv
 from ryu.lib import igmplib
 from ryu.lib.dpid import str_to_dpid
+from ryu.ofproto.ofproto_parser import buffer
 
 
 class SimpleSwitchIgmp(app_manager.RyuApp):


### PR DESCRIPTION
Fix error:
NameError: name 'buffer' is not defined
SimpleSwitchIgmp: Exception occurred during handler processing. Backtrace from offending handler [_packet_in_handler] servicing event [EventPacketIn] follows.