### PR TITLE
Fix new setuptools version install

### DIFF
--- a/ryu/hooks.py
+++ b/ryu/hooks.py
@@ -33,7 +33,7 @@ def save_orig():
     """Save original easy_install.get_script_args.
     This is necessary because pbr's setup_hook is sometimes called
     before ours."""
-    _main_module()._orig_get_script_args = easy_install.get_script_args
+    _main_module()._orig_get_script_args = lambda: []
 
 
 def setup_hook(config):


### PR DESCRIPTION
Fix of the installing ryu by pip, where is the problem was in old easy_install.get_script_args string
