### PR TITLE
Fix: replacing the old "easy_install.get_script_args" with the new setuptools version "ScripWriter.get_args".

### DIFF
--- a/ryu/hooks.py
+++ b/ryu/hooks.py
@@ -17,7 +17,7 @@
 
 import os
 import sys
-from setuptools.command import easy_install
+from setuptools.command import ScriptWriter
 from ryu import version
 
 
@@ -33,7 +33,7 @@ def save_orig():
     """Save original easy_install.get_script_args.
     This is necessary because pbr's setup_hook is sometimes called
     before ours."""
-    _main_module()._orig_get_script_args = easy_install.get_script_args
+    _main_module()._orig_get_script_args = ScriptWriter.get_args
 
 
 def setup_hook(config):
@@ -57,7 +57,7 @@ def setup_hook(config):
         return _main_module()._orig_get_script_args(*args, **kwargs)
 
     packaging.override_get_script_args = my_get_script_args
-    easy_install.get_script_args = my_get_script_args
+    ScriptWriter.get_args = my_get_script_args
 
     # another hack to allow setup from tarball.
     orig_get_version = packaging.get_version

--- a/ryu/hooks.py
+++ b/ryu/hooks.py
@@ -17,7 +17,7 @@
 
 import os
 import sys
-from setuptools.command import ScriptWriter
+from setuptools.command.easy_install import ScriptWriter
 from ryu import version
 
 


### PR DESCRIPTION
Coming across the "ryu" project while on working on sdn, the installation process had an issue ( #201 ) in the hooks code ( using easy_install a setuptools older version code tool ) so I replace it with the new tool ScriptWriter.